### PR TITLE
DM-14837 Firefly improvements to intro-with-globular notebook

### DIFF
--- a/workshops/lyon2018/intro-with-globular.ipynb
+++ b/workshops/lyon2018/intro-with-globular.ipynb
@@ -283,7 +283,7 @@
     "# We'll customize the configuration of measurement to just run a few plugins.\n",
     "# The default list of plugins is much longer (and hence slower).\n",
     "measureConfig = SingleFrameMeasurementTask.ConfigClass()\n",
-    "measureConfig.plugins.names = [\"base_SdssCentroid\", \"base_PsfFlux\"]\n",
+    "measureConfig.plugins.names = [\"base_SdssCentroid\", \"base_PsfFlux\", \"base_SkyCoord\"]\n",
     "# \"Slots\" are aliases that provide easy access to certain plugins.\n",
     "# Because we're not running the plugin these slots refer to by default,\n",
     "# we need to disable them in the configuration.\n",
@@ -451,19 +451,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from lsst.afw.display import setDefaultBackend, getDisplay\n",
+    "from lsst.afw.display import setDefaultBackend, Display\n",
     "from IPython.display import IFrame\n",
     "import os\n",
     "setDefaultBackend(\"firefly\")\n",
-    "channel = '{}_test_channel'.format(os.environ['USER'])\n",
-    "server = 'https://lsp-demo.lsst.codes'"
+    "channel = '{}_test_channel'.format(os.environ['USER'])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Execute the next cell if you want to use Firefly from within a notebook cell.  You can also use a different browser tab/window (a link will appear a few cells below).  There's nothing stopping you from using both, but it can be a little confusing since you might need to refresh one or wait a bit to see changes you make in the other."
+    "In LSST Science Platform environments, we have prepopulated environment variables `FIREFLY_URL` and `FIREFLY_HTML` with the Firefly server URL and the landing page or html file on that server. These are picked up automatically when creating the display. In the previous cell, we generated a user-specific channel name; if unspecified, a random channel name is generated."
    ]
   },
   {
@@ -472,14 +471,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "IFrame('{}/firefly/slate.html?__wsch={}'.format(server, channel), 1024, 768)"
+    "display = Display(frame=1, name=channel)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In either case, we now need to create a Python display object associated with one frame in the Firefly window (that will also give us that link):"
+    "The link that appears above will open a different browser tab/window for the Firefly viewer. Execute the next cell if you want to use Firefly from within a notebook cell. There's nothing stopping you from using both, but it can be a little confusing since you might need to refresh one or wait a bit to see changes you make in the other."
    ]
   },
   {
@@ -488,7 +487,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "display = getDisplay(frame=1, name=channel)"
+    "IFrame(display._url, 1024, 768)"
    ]
   },
   {
@@ -518,7 +517,31 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The function below overplots the sources we detected on the image.  Firefly itself has much more sophisticated ways of interacting them with catalogs, but we haven't gotten them integrated fully with our Python libraries yet."
+    "Mask transparency can also be controlled using `afw.display`, for individual planes or for all."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display.setMaskTransparency(10)\n",
+    "display.setMaskTransparency(30, 'DETECTED')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In future code updates, these transparency settings will be made \"sticky\" for each Display, and settable by default. For now, we can set the transparency after each image display."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The function below overplots the sources we detected on the image.  Firefly itself has much more sophisticated ways of interacting them with catalogs; an example will be shown at the end of the notebook."
    ]
   },
   {
@@ -683,8 +706,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "display2 = getDisplay(frame=2, name=channel)\n",
-    "display2.mtv(residuals, title=\"residuals\")"
+    "display2 = Display(frame=2, name=channel)\n",
+    "display2.mtv(residuals, title=\"residuals\")\n",
+    "display2.setMaskTransparency(10)\n",
+    "display2.setMaskTransparency(30, 'DETECTED')"
    ]
   },
   {
@@ -693,7 +718,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "display3 = getDisplay(frame=3, name=channel)\n",
+    "display3 = Display(frame=3, name=channel)\n",
     "display3.mtv(model, title=\"model\")"
    ]
   },
@@ -819,6 +844,8 @@
    "outputs": [],
    "source": [
     "display2.mtv(residuals, title=\"residuals\")\n",
+    "display2.setMaskTransparency(10)\n",
+    "display2.setMaskTransparency(30, 'DETECTED')\n",
     "display3.mtv(model, title=\"model\")"
    ]
   },
@@ -828,7 +855,23 @@
    "source": [
     "The results are better than the last subtraction, but still not great.\n",
     "\n",
-    "Note that you may need to set the stretch manually (histogram button) to give the residuals image the same stretch as the others.  For this image, I recommend setting the stretch using \"Data\" bounds of `(-0.05, 2)` with the original image selected, and then blinking to the other frames while the stretch window is open.  (Firefly experts in the room may have a better way to do this)."
+    "Note that you may need to set the stretch manually (histogram button) to give the residuals image the same stretch as the others.  For this image, I recommend setting the stretch using \"Data\" bounds of `(-0.05, 2)` with the original image selected, and then blinking to the other frames while the stretch window is open.  "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The stretch is also settable programmatically:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display2.scale('linear', -0.05, 2)"
    ]
   },
   {
@@ -928,7 +971,18 @@
    "outputs": [],
    "source": [
     "display2.mtv(residuals, title=\"residuals\")\n",
+    "display2.setMaskTransparency(5)\n",
+    "display2.setMaskTransparency(30, 'DETECTED')\n",
     "display3.mtv(model, title=\"model\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display2.scale('linear', -0.05, 2)"
    ]
   },
   {
@@ -936,6 +990,84 @@
    "metadata": {},
    "source": [
     "Even better!  One more iteration *might* make things better, but we're probably getting to the limits of this very simple algorithm (especially since there really are a lot of galaxies in this image)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Uploading the catalog directly to Firefly"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As noted earlier, Firefly has sophisticated capabilities for viewing tables and overlaying catalogs. The `firefly_client` Python package underlies the Firefly backend in `lsst.afw.display`. The `firefly_client.plot` module includes convenience functions that we'll demonstrate here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import firefly_client.plot as ffplt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Ensure we use the same setup as our Display instances:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ffplt.use_client(display._client)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Upload our combined catalog to Firefly. By default, the catalog will be shown in an interactive table viewer. Since the catalog contains coordinate columns recognized by Firefly, the catalog entries will be overlaid on the images."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tbl_id = ffplt.upload_table(combined, title='combined catalog')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Firefly includes plotting capabilities using the Plotly.js library. We'll end this section with a histogram of flux values. `ffplt.scatter` can be used to make a scatter plot of two columns for a table. These functions use the table ID of the last uploaded table by default; the `tbl_id` we saved in the last cell can be passed as an optional argument."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ffplt.hist('log10(base_PsfFlux_flux)')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The table, plot, and image cells can be resized and moved around in the Firefly viewer."
    ]
   },
   {

--- a/workshops/lyon2018/intro-with-globular.ipynb
+++ b/workshops/lyon2018/intro-with-globular.ipynb
@@ -1019,7 +1019,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ensure we use the same setup as our Display instances:"
+    "The `firefly_client.plot` module should default to the client that is used in the `afw.display` Displays we defined earlier, so long as a browser tab or IFrame is connected to those displays. If not, the next line may be uncommented to ensure we use the same setup as our Display instances."
    ]
   },
   {
@@ -1028,7 +1028,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ffplt.use_client(display._client)"
+    "#ffplt.use_client(display._client)"
    ]
   },
   {


### PR DESCRIPTION
A small set of additions to the `intro-with-globular` notebook to improve the image display and to demonstrate Firefly capabilities for catalog upload and plotting.

* use Display instead of getDisplay per RHL's recommendation
* use the Display's URL for the IFrame
* add mask transparency and stretch commands
* add section demonstrating catalog upload, overlay and plotting